### PR TITLE
Add referee management and scheduling

### DIFF
--- a/backend/models/referees.py
+++ b/backend/models/referees.py
@@ -1,0 +1,26 @@
+"""Domain models for referee management."""
+from __future__ import annotations
+
+from datetime import date
+from pydantic import BaseModel
+
+
+class Referee(BaseModel):
+    """Represents a match official."""
+    id: int
+    name: str
+    level: str = "regional"
+
+
+class Availability(BaseModel):
+    """Availability entry for a referee on a given date."""
+    referee_id: int
+    date: date
+
+
+class Match(BaseModel):
+    """Simplified match representation with assigned referee."""
+    home: str
+    away: str
+    date: date
+    referee_id: int | None = None

--- a/backend/routes/referees.py
+++ b/backend/routes/referees.py
@@ -1,0 +1,100 @@
+"""Routes for referee CRUD and match planning."""
+from __future__ import annotations
+
+import itertools
+from datetime import date
+from typing import Dict, List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..models.referees import Availability, Match, Referee
+
+router = APIRouter(prefix="/referees")
+
+# in-memory storage
+_referees: Dict[int, Referee] = {}
+_availability: Dict[int, set[date]] = {}
+_id_sequence = itertools.count(1)
+
+
+class RefereeCreate(BaseModel):
+    name: str
+    level: str = "regional"
+
+
+@router.post("", response_model=Referee)
+def create_referee(payload: RefereeCreate) -> Referee:
+    referee_id = next(_id_sequence)
+    referee = Referee(id=referee_id, **payload.dict())
+    _referees[referee_id] = referee
+    return referee
+
+
+@router.get("", response_model=List[Referee])
+def list_referees() -> List[Referee]:
+    return list(_referees.values())
+
+
+@router.get("/{referee_id}", response_model=Referee)
+def get_referee(referee_id: int) -> Referee:
+    referee = _referees.get(referee_id)
+    if not referee:
+        raise HTTPException(status_code=404, detail="Referee not found")
+    return referee
+
+
+@router.put("/{referee_id}", response_model=Referee)
+def update_referee(referee_id: int, payload: RefereeCreate) -> Referee:
+    if referee_id not in _referees:
+        raise HTTPException(status_code=404, detail="Referee not found")
+    referee = Referee(id=referee_id, **payload.dict())
+    _referees[referee_id] = referee
+    return referee
+
+
+@router.delete("/{referee_id}")
+def delete_referee(referee_id: int) -> dict:
+    if referee_id not in _referees:
+        raise HTTPException(status_code=404, detail="Referee not found")
+    _referees.pop(referee_id)
+    _availability.pop(referee_id, None)
+    return {"status": "deleted"}
+
+
+class AvailabilityRequest(BaseModel):
+    date: date
+
+
+@router.post("/{referee_id}/availability", response_model=Availability)
+def add_availability(referee_id: int, payload: AvailabilityRequest) -> Availability:
+    if referee_id not in _referees:
+        raise HTTPException(status_code=404, detail="Referee not found")
+    _availability.setdefault(referee_id, set()).add(payload.date)
+    return Availability(referee_id=referee_id, date=payload.date)
+
+
+@router.get("/{referee_id}/availability", response_model=List[Availability])
+def list_availability(referee_id: int) -> List[Availability]:
+    if referee_id not in _referees:
+        raise HTTPException(status_code=404, detail="Referee not found")
+    dates = _availability.get(referee_id, set())
+    return [Availability(referee_id=referee_id, date=d) for d in sorted(dates)]
+
+
+class MatchCreate(BaseModel):
+    home: str
+    away: str
+    date: date
+
+
+@router.post("/schedule", response_model=List[Match])
+def schedule_matches(matches: List[MatchCreate]) -> List[Match]:
+    assigned: List[Match] = []
+    for match in matches:
+        referee_id = next((rid for rid, dates in _availability.items() if match.date in dates), None)
+        if referee_id is None:
+            raise HTTPException(status_code=400, detail=f"No referee available for {match.date}")
+        _availability[referee_id].remove(match.date)
+        assigned.append(Match(**match.dict(), referee_id=referee_id))
+    return assigned

--- a/backend/tests/test_referees.py
+++ b/backend/tests/test_referees.py
@@ -1,0 +1,44 @@
+from datetime import date
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes.referees import router
+
+app = FastAPI()
+app.include_router(router)
+
+
+def test_referee_crud_flow():
+    client = TestClient(app)
+    # create
+    resp = client.post("/referees", json={"name": "Ana", "level": "senior"})
+    assert resp.status_code == 200
+    referee = resp.json()
+    rid = referee["id"]
+    # read
+    assert client.get(f"/referees/{rid}").json()["name"] == "Ana"
+    # update
+    resp = client.put(f"/referees/{rid}", json={"name": "Ana B", "level": "senior"})
+    assert resp.json()["name"] == "Ana B"
+    # list
+    assert len(client.get("/referees").json()) == 1
+    # delete
+    assert client.delete(f"/referees/{rid}").status_code == 200
+    assert client.get(f"/referees/{rid}").status_code == 404
+
+
+def test_schedule_with_availability():
+    client = TestClient(app)
+    # create referee and availability
+    rid = client.post("/referees", json={"name": "Luis"}).json()["id"]
+    avail_date = date(2024, 1, 1).isoformat()
+    client.post(f"/referees/{rid}/availability", json={"date": avail_date})
+    # plan match
+    resp = client.post(
+        "/referees/schedule",
+        json=[{"home": "A", "away": "B", "date": avail_date}],
+    )
+    assert resp.status_code == 200
+    assigned = resp.json()[0]
+    assert assigned["referee_id"] == rid

--- a/frontend/app/referees/assign/page.tsx
+++ b/frontend/app/referees/assign/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function AssignRefereesPage() {
+  const [home, setHome] = useState('')
+  const [away, setAway] = useState('')
+  const [date, setDate] = useState('')
+  const [result, setResult] = useState<any>(null)
+
+  async function schedule(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/api/referees/schedule', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([{ home, away, date }])
+    })
+    setResult(await res.json())
+  }
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Assign Referees</h1>
+      <form onSubmit={schedule} className="space-x-2 mb-4">
+        <input value={home} onChange={e => setHome(e.target.value)} placeholder="Home" className="border px-2" />
+        <input value={away} onChange={e => setAway(e.target.value)} placeholder="Away" className="border px-2" />
+        <input type="date" value={date} onChange={e => setDate(e.target.value)} className="border px-2" />
+        <button type="submit" className="bg-green-500 text-white px-2">Schedule</button>
+      </form>
+      {result && (
+        <pre className="bg-gray-100 p-2">{JSON.stringify(result, null, 2)}</pre>
+      )}
+    </div>
+  )
+}

--- a/frontend/app/referees/page.tsx
+++ b/frontend/app/referees/page.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Referee {
+  id: number
+  name: string
+  level: string
+}
+
+export default function RefereesPage() {
+  const [refs, setRefs] = useState<Referee[]>([])
+  const [name, setName] = useState('')
+  const [level, setLevel] = useState('regional')
+
+  useEffect(() => {
+    fetch('/api/referees')
+      .then(res => res.json())
+      .then(setRefs)
+  }, [])
+
+  async function addReferee(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/api/referees', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, level })
+    })
+    const data = await res.json()
+    setRefs([...refs, data])
+    setName('')
+  }
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Referees</h1>
+      <form onSubmit={addReferee} className="mb-4 space-x-2">
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="border px-2" />
+        <select value={level} onChange={e => setLevel(e.target.value)} className="border px-2">
+          <option value="regional">Regional</option>
+          <option value="senior">Senior</option>
+        </select>
+        <button type="submit" className="bg-blue-500 text-white px-2">Add</button>
+      </form>
+      <ul>
+        {refs.map(r => (
+          <li key={r.id}>{r.name} - {r.level}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Referee and Availability models
- expose CRUD and scheduling routes for referees
- build simple frontend pages to manage and assign referees

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ece55228832c8f21030afff59e38