### PR TITLE
Add basic messaging models, routes, frontend and tests

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+Base = declarative_base()
+
+__all__ = ["Base", "engine", "SessionLocal"]

--- a/backend/models/conversations.py
+++ b/backend/models/conversations.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+
+from . import Base
+
+
+class Conversation(Base):
+    __tablename__ = "conversations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=True)
+
+    messages = relationship("Message", back_populates="conversation", cascade="all, delete-orphan")

--- a/backend/models/messages.py
+++ b/backend/models/messages.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import relationship
+
+from . import Base
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    conversation_id = Column(Integer, ForeignKey("conversations.id", ondelete="CASCADE"))
+    sender = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    timestamp = Column(DateTime, server_default=func.now(), nullable=False)
+
+    conversation = relationship("Conversation", back_populates="messages")

--- a/backend/routes/messages.py
+++ b/backend/routes/messages.py
@@ -1,0 +1,75 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..models import SessionLocal, Base, engine
+from ..models.conversations import Conversation
+from ..models.messages import Message
+
+router = APIRouter()
+
+# Create tables when router is imported
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+class ConversationCreate(BaseModel):
+    title: str | None = None
+
+
+@router.post("/conversations")
+def create_conversation(conversation: ConversationCreate, db: Session = Depends(get_db)):
+    convo = Conversation(title=conversation.title)
+    db.add(convo)
+    db.commit()
+    db.refresh(convo)
+    return {"id": convo.id, "title": convo.title}
+
+
+class MessageCreate(BaseModel):
+    sender: str
+    content: str
+
+
+@router.post("/conversations/{conversation_id}/messages")
+def create_message(conversation_id: int, message: MessageCreate, db: Session = Depends(get_db)):
+    convo = db.get(Conversation, conversation_id)
+    if not convo:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    msg = Message(conversation_id=conversation_id, sender=message.sender, content=message.content)
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return {
+        "id": msg.id,
+        "conversation_id": msg.conversation_id,
+        "sender": msg.sender,
+        "content": msg.content,
+        "timestamp": msg.timestamp.isoformat(),
+    }
+
+
+@router.get("/conversations/{conversation_id}/messages")
+def read_messages(conversation_id: int, db: Session = Depends(get_db)):
+    messages = (
+        db.query(Message)
+        .filter(Message.conversation_id == conversation_id)
+        .order_by(Message.timestamp)
+        .all()
+    )
+    return [
+        {
+            "id": m.id,
+            "sender": m.sender,
+            "content": m.content,
+            "timestamp": m.timestamp.isoformat(),
+        }
+        for m in messages
+    ]

--- a/backend/tests/test_messages.py
+++ b/backend/tests/test_messages.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes.messages import router
+from backend.models import Base, engine
+
+app = FastAPI()
+app.include_router(router)
+
+
+def setup_module(module):
+    # Reset database for tests
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def test_message_flow():
+    client = TestClient(app)
+    # Create conversation
+    response = client.post("/conversations", json={"title": "General"})
+    assert response.status_code == 200
+    convo = response.json()
+    convo_id = convo["id"]
+
+    # Send messages
+    r1 = client.post(
+        f"/conversations/{convo_id}/messages",
+        json={"sender": "Alice", "content": "Hola"},
+    )
+    assert r1.status_code == 200
+    r2 = client.post(
+        f"/conversations/{convo_id}/messages",
+        json={"sender": "Bob", "content": "Qué tal"},
+    )
+    assert r2.status_code == 200
+
+    # Fetch messages
+    r3 = client.get(f"/conversations/{convo_id}/messages")
+    assert r3.status_code == 200
+    messages = r3.json()
+    assert len(messages) == 2
+    assert messages[0]["content"] == "Hola"
+    assert messages[1]["sender"] == "Bob"

--- a/frontend/app/messages/page.tsx
+++ b/frontend/app/messages/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Message {
+  id: number;
+  sender: string;
+  content: string;
+  timestamp: string;
+}
+
+export default function MessagesPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+
+  async function fetchMessages() {
+    try {
+      const res = await fetch("http://localhost:8000/conversations/1/messages");
+      if (res.ok) {
+        const data = await res.json();
+        setMessages(data);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  useEffect(() => {
+    fetchMessages();
+    const interval = setInterval(fetchMessages, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  async function sendMessage() {
+    if (!input) return;
+    await fetch("http://localhost:8000/conversations/1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sender: "User", content: input }),
+    });
+    setInput("");
+    fetchMessages();
+  }
+
+  return (
+    <div>
+      <h1>Messages</h1>
+      <ul>
+        {messages.map((m) => (
+          <li key={m.id}>
+            <strong>{m.sender}:</strong> {m.content}
+          </li>
+        ))}
+      </ul>
+      <input
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        placeholder="Type message"
+      />
+      <button onClick={sendMessage}>Send</button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- define SQLAlchemy models for conversations and messages
- add FastAPI routes for creating conversations and posting/reading messages
- implement simple Next.js messages page with polling
- cover message flow with integration test

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ecdfd79c832ca0bf091e4b105a87