### PR TITLE
Add field booking models, routes, UI, and payment integration

### DIFF
--- a/backend/core/payments.py
+++ b/backend/core/payments.py
@@ -1,0 +1,19 @@
+"""Simplified payment processing utilities."""
+from __future__ import annotations
+
+
+def process_payment(provider: str, amount: float) -> str:
+    """Process a payment through the selected provider.
+
+    This is a lightweight placeholder implementation which simulates
+    successful payments for MercadoPago and Stripe. In a real-world
+    scenario, this function would interact with the providers' SDKs.
+    """
+    provider = provider.lower()
+    if provider == "stripe":
+        # Simulate Stripe payment processing
+        return f"stripe_{int(amount * 100)}"
+    if provider == "mercadopago":
+        # Simulate MercadoPago payment processing
+        return f"mp_{int(amount * 100)}"
+    raise ValueError("Unsupported payment provider")

--- a/backend/models/fields.py
+++ b/backend/models/fields.py
@@ -1,0 +1,23 @@
+"""Domain models for field management and bookings."""
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class Field(BaseModel):
+    """Represents a sports field available for booking."""
+    id: int
+    name: str
+    location: str
+    price_per_hour: float
+
+
+class Booking(BaseModel):
+    """Booking record for a field reservation."""
+    id: int
+    field_id: int
+    start_time: datetime
+    end_time: datetime
+    paid: bool = False
+    payment_id: str | None = None

--- a/backend/routes/fields.py
+++ b/backend/routes/fields.py
@@ -1,0 +1,69 @@
+"""Routes for field listing and booking with payment integration."""
+from __future__ import annotations
+
+import itertools
+from datetime import datetime
+from typing import Dict, List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ..core.payments import process_payment
+from ..models.fields import Booking, Field
+
+router = APIRouter(prefix="/fields")
+
+# in-memory storage
+_fields: Dict[int, Field] = {}
+_bookings: Dict[int, Booking] = {}
+_field_id_seq = itertools.count(1)
+_booking_id_seq = itertools.count(1)
+
+
+class FieldCreate(BaseModel):
+    name: str
+    location: str
+    price_per_hour: float
+
+
+class BookingRequest(BaseModel):
+    start_time: datetime
+    end_time: datetime
+    provider: str
+
+
+@router.post("", response_model=Field)
+def create_field(payload: FieldCreate) -> Field:
+    field_id = next(_field_id_seq)
+    field = Field(id=field_id, **payload.dict())
+    _fields[field_id] = field
+    return field
+
+
+@router.get("", response_model=List[Field])
+def list_fields() -> List[Field]:
+    return list(_fields.values())
+
+
+@router.post("/{field_id}/bookings", response_model=Booking)
+def book_field(field_id: int, payload: BookingRequest) -> Booking:
+    field = _fields.get(field_id)
+    if not field:
+        raise HTTPException(status_code=404, detail="Field not found")
+    payment_id = process_payment(payload.provider, field.price_per_hour)
+    booking_id = next(_booking_id_seq)
+    booking = Booking(
+        id=booking_id,
+        field_id=field_id,
+        start_time=payload.start_time,
+        end_time=payload.end_time,
+        paid=True,
+        payment_id=payment_id,
+    )
+    _bookings[booking_id] = booking
+    return booking
+
+
+@router.get("/bookings", response_model=List[Booking])
+def list_bookings() -> List[Booking]:
+    return list(_bookings.values())

--- a/backend/tests/test_fields.py
+++ b/backend/tests/test_fields.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes.fields import router
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+def test_field_booking_flow():
+    # create field
+    res = client.post(
+        "/fields",
+        json={"name": "Central Park", "location": "NYC", "price_per_hour": 50.0},
+    )
+    assert res.status_code == 200
+    field = res.json()
+
+    # list fields
+    res = client.get("/fields")
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+
+    # book field
+    booking_payload = {
+        "start_time": "2024-01-01T10:00:00Z",
+        "end_time": "2024-01-01T11:00:00Z",
+        "provider": "stripe",
+    }
+    res = client.post(f"/fields/{field['id']}/bookings", json=booking_payload)
+    assert res.status_code == 200
+    booking = res.json()
+    assert booking["paid"] is True
+    assert booking["payment_id"].startswith("stripe_")

--- a/frontend/app/fields/page.tsx
+++ b/frontend/app/fields/page.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Field {
+  id: number
+  name: string
+  location: string
+  price_per_hour: number
+}
+
+export default function FieldsPage() {
+  const [fields, setFields] = useState<Field[]>([])
+  const [provider, setProvider] = useState('stripe')
+
+  useEffect(() => {
+    fetch('/api/fields')
+      .then(res => res.json())
+      .then(setFields)
+  }, [])
+
+  async function book(fieldId: number) {
+    const now = new Date()
+    const end = new Date(now.getTime() + 60 * 60 * 1000)
+    await fetch(`/api/fields/${fieldId}/bookings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        start_time: now.toISOString(),
+        end_time: end.toISOString(),
+        provider
+      })
+    })
+    alert('Reserva confirmada')
+  }
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Canchas</h1>
+      <div className="mb-4">
+        <label className="mr-2">Proveedor de pago:</label>
+        <select value={provider} onChange={e => setProvider(e.target.value)} className="border px-2">
+          <option value="stripe">Stripe</option>
+          <option value="mercadopago">MercadoPago</option>
+        </select>
+      </div>
+      <ul>
+        {fields.map(f => (
+          <li key={f.id} className="mb-2">
+            <span className="mr-2">{f.name} - {f.location} (${f.price_per_hour}/h)</span>
+            <button onClick={() => book(f.id)} className="bg-green-500 text-white px-2">Reservar</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Field and Booking pydantic models
- create payment helper for MercadoPago/Stripe and field booking API
- build simple Fields UI for listing and reserving with provider selection

## Testing
- `pytest -q`
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee89abbc832cb8478ece89112883