### PR TITLE
Add ranking service with endpoint and frontend page

### DIFF
--- a/backend/models/referees.py
+++ b/backend/models/referees.py
@@ -1,7 +1,7 @@
 """Domain models for referee management."""
 from __future__ import annotations
 
-from datetime import date
+from datetime import date as Date
 from pydantic import BaseModel
 
 
@@ -15,12 +15,12 @@ class Referee(BaseModel):
 class Availability(BaseModel):
     """Availability entry for a referee on a given date."""
     referee_id: int
-    date: date
+    date: Date
 
 
 class Match(BaseModel):
     """Simplified match representation with assigned referee."""
     home: str
     away: str
-    date: date
+    date: Date
     referee_id: int | None = None

--- a/backend/routes/ranking.py
+++ b/backend/routes/ranking.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+from ..services.ranking import SAMPLE_MATCHES, calculate_ranking
+
+router = APIRouter()
+
+
+@router.get("/ranking")
+def get_ranking():
+    """Expose ranking computed from tournament results."""
+    return calculate_ranking(SAMPLE_MATCHES)

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 
+
 @router.get("/summary")
 def get_summary_stats():
     """Return consolidated summary statistics for the dashboard."""
@@ -11,6 +12,7 @@ def get_summary_stats():
         "total_matches": 66,
         "avg_goals_per_match": 3.2,
     }
+
 
 @router.get("/players/top")
 def get_top_players():

--- a/backend/services/ranking.py
+++ b/backend/services/ranking.py
@@ -1,0 +1,67 @@
+from collections import defaultdict
+from typing import Iterable, List, Dict
+
+Match = Dict[str, int | str]
+
+# Sample match data to illustrate ranking calculations
+SAMPLE_MATCHES: List[Match] = [
+    {"home": "Team A", "away": "Team B", "home_goals": 2, "away_goals": 1},
+    {"home": "Team C", "away": "Team A", "home_goals": 0, "away_goals": 3},
+    {"home": "Team B", "away": "Team C", "home_goals": 1, "away_goals": 1},
+]
+
+
+def calculate_ranking(matches: Iterable[Match]) -> List[Dict[str, int | str]]:
+    """Aggregate match results into a ranking table.
+
+    Teams are ordered by points, goal difference and goals scored.
+    """
+    stats: Dict[str, Dict[str, int]] = defaultdict(
+        lambda: {
+            "played": 0,
+            "wins": 0,
+            "draws": 0,
+            "losses": 0,
+            "goals_for": 0,
+            "goals_against": 0,
+            "points": 0,
+        }
+    )
+
+    for m in matches:
+        home = m["home"]
+        away = m["away"]
+        hg = int(m["home_goals"])
+        ag = int(m["away_goals"])
+
+        stats[home]["played"] += 1
+        stats[away]["played"] += 1
+        stats[home]["goals_for"] += hg
+        stats[home]["goals_against"] += ag
+        stats[away]["goals_for"] += ag
+        stats[away]["goals_against"] += hg
+
+        if hg > ag:
+            stats[home]["wins"] += 1
+            stats[away]["losses"] += 1
+            stats[home]["points"] += 3
+        elif hg < ag:
+            stats[away]["wins"] += 1
+            stats[home]["losses"] += 1
+            stats[away]["points"] += 3
+        else:
+            stats[home]["draws"] += 1
+            stats[away]["draws"] += 1
+            stats[home]["points"] += 1
+            stats[away]["points"] += 1
+
+    table = []
+    for team, s in stats.items():
+        s["goal_difference"] = s["goals_for"] - s["goals_against"]
+        table.append({"team": team, **s})
+
+    return sorted(
+        table,
+        key=lambda t: (t["points"], t["goal_difference"], t["goals_for"]),
+        reverse=True,
+    )

--- a/backend/tests/test_ranking.py
+++ b/backend/tests/test_ranking.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routes.ranking import router
+
+app = FastAPI()
+app.include_router(router)
+
+
+def test_ranking_endpoint_returns_sorted_table():
+    client = TestClient(app)
+    resp = client.get("/ranking")
+    assert resp.status_code == 200
+    table = resp.json()
+    assert len(table) > 0
+    points = [row["points"] for row in table]
+    assert points == sorted(points, reverse=True)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,13 @@
+# Arquitectura
+
+## Criterios de Ranking
+
+El servicio de ranking consolida los resultados de los partidos y calcula la
+clasificación de los equipos utilizando los siguientes criterios:
+
+1. **Puntos:** 3 por victoria, 1 por empate y 0 por derrota.
+2. **Diferencia de goles:** goles a favor menos goles en contra.
+3. **Goles a favor:** se usa como tercer criterio de desempate.
+
+Los equipos se ordenan de forma descendente considerando, en ese orden, los
+puntos obtenidos, la diferencia de goles y los goles a favor.

--- a/frontend/app/ranking.tsx
+++ b/frontend/app/ranking.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+interface TeamRow {
+  team: string;
+  played: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  goals_for: number;
+  goals_against: number;
+  goal_difference: number;
+  points: number;
+}
+
+export default function RankingPage() {
+  const [rows, setRows] = useState<TeamRow[]>([]);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/ranking')
+      .then((res) => res.json())
+      .then(setRows)
+      .catch(console.error);
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Ranking</h1>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border px-2">#</th>
+            <th className="border px-2">Team</th>
+            <th className="border px-2">Pts</th>
+            <th className="border px-2">PJ</th>
+            <th className="border px-2">DG</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, idx) => (
+            <tr key={r.team}>
+              <td className="border px-2">{idx + 1}</td>
+              <td className="border px-2">{r.team}</td>
+              <td className="border px-2">{r.points}</td>
+              <td className="border px-2">{r.played}</td>
+              <td className="border px-2">{r.goal_difference}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add tournament ranking service and expose `/ranking` endpoint
- show ranking table on new frontend page
- document ranking criteria in architecture docs

## Testing
- `flake8 backend --max-line-length=120`
- `pytest backend/tests -q`
- `cd frontend && npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee904054832c8a536d7519f19dc1