### PR TITLE
feat: add API-Football integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for external services
+API_FOOTBALL_HOST=https://api-football-v1.p.rapidapi.com/v3
+API_FOOTBALL_KEY=replace_me

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,23 @@
+"""Main FastAPI application including external API integrations."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from backend.routes import fields, messages, referees, ranking, stats, tournaments
+from backend.services.api_football import fetch_leagues
+
+app = FastAPI()
+
+# Include existing routers
+app.include_router(fields.router)
+app.include_router(messages.router)
+app.include_router(referees.router)
+app.include_router(ranking.router)
+app.include_router(stats.router)
+app.include_router(tournaments.router)
+
+
+@app.get("/external-leagues")
+def external_leagues(country: str | None = None):
+    """Return league data from API-Football."""
+    return fetch_leagues(country)

--- a/backend/services/api_football.py
+++ b/backend/services/api_football.py
@@ -1,0 +1,33 @@
+"""Simple client for API-Football.com."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+API_FOOTBALL_HOST = os.getenv("API_FOOTBALL_HOST", "https://api-football-v1.p.rapidapi.com/v3")
+API_FOOTBALL_KEY = os.getenv("API_FOOTBALL_KEY", "")
+
+
+def fetch_leagues(country: Optional[str] = None) -> Dict[str, Any]:
+    """Fetch league information from API-Football.
+
+    Parameters
+    ----------
+    country: str | None
+        Optional country filter.
+
+    Returns
+    -------
+    dict
+        Parsed JSON response from the API.
+    """
+    headers = {"x-rapidapi-key": API_FOOTBALL_KEY}
+    params: Dict[str, Any] = {}
+    if country:
+        params["country"] = country
+    url = f"{API_FOOTBALL_HOST}/leagues"
+    resp = requests.get(url, headers=headers, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json()

--- a/backend/tests/test_api_football.py
+++ b/backend/tests/test_api_football.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+from backend.services import api_football
+
+
+def test_external_leagues(monkeypatch):
+    def fake_get(url, headers=None, params=None, timeout=None):
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"response": [{"league": {"name": "Test League"}}]}
+
+        return FakeResp()
+
+    monkeypatch.setattr(api_football.requests, "get", fake_get)
+    client = TestClient(app)
+    resp = client.get("/external-leagues")
+    assert resp.status_code == 200
+    assert resp.json()["response"][0]["league"]["name"] == "Test League"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,3 +11,15 @@ clasificación de los equipos utilizando los siguientes criterios:
 
 Los equipos se ordenan de forma descendente considerando, en ese orden, los
 puntos obtenidos, la diferencia de goles y los goles a favor.
+
+## Integración con API-Football
+
+El backend puede consultar datos de ligas externas a través del endpoint `/external-leagues`.
+El flujo de integración es el siguiente:
+
+1. `main.py` recibe la petición REST.
+2. Se llama al servicio `services/api_football.py`.
+3. El servicio realiza la solicitud HTTP a API-Football usando las variables de entorno `API_FOOTBALL_HOST` y `API_FOOTBALL_KEY`.
+4. La respuesta de la API externa se devuelve al cliente sin modificaciones.
+
+Para ejecutar localmente se deben definir dichas variables de entorno (ver `.env.example`).


### PR DESCRIPTION
## Summary
- add service wrapper for API-Football
- expose `/external-leagues` endpoint in main FastAPI app
- document external integration and environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6efff2fcc832cac8ccb382a03aae6