### PR TITLE
Implement database-backed field bookings

### DIFF
--- a/backend/models/fields.py
+++ b/backend/models/fields.py
@@ -1,23 +1,38 @@
 """Domain models for field management and bookings."""
 from __future__ import annotations
 
-from datetime import datetime
-from pydantic import BaseModel
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from . import Base
 
 
-class Field(BaseModel):
+class Field(Base):
     """Represents a sports field available for booking."""
-    id: int
-    name: str
-    location: str
-    price_per_hour: float
+
+    __tablename__ = "fields"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    location = Column(String, nullable=False)
+    price_per_hour = Column(Float, nullable=False)
+
+    bookings = relationship(
+        "Booking", back_populates="field", cascade="all, delete-orphan"
+    )
 
 
-class Booking(BaseModel):
+class Booking(Base):
     """Booking record for a field reservation."""
-    id: int
-    field_id: int
-    start_time: datetime
-    end_time: datetime
-    paid: bool = False
-    payment_id: str | None = None
+
+    __tablename__ = "bookings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    field_id = Column(Integer, ForeignKey("fields.id", ondelete="CASCADE"))
+    start_time = Column(DateTime, nullable=False)
+    end_time = Column(DateTime, nullable=False)
+    paid = Column(Boolean, default=False, nullable=False)
+    payment_id = Column(String, nullable=True)
+
+    field = relationship("Field", back_populates="bookings")
+

--- a/backend/tests/test_fields.py
+++ b/backend/tests/test_fields.py
@@ -1,14 +1,21 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from backend.models import Base, engine
 from backend.routes.fields import router
 
 app = FastAPI()
 app.include_router(router)
-client = TestClient(app)
+
+
+def setup_module(module):
+    # Reset database for tests
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
 
 
 def test_field_booking_flow():
+    client = TestClient(app)
     # create field
     res = client.post(
         "/fields",
@@ -33,3 +40,4 @@ def test_field_booking_flow():
     booking = res.json()
     assert booking["paid"] is True
     assert booking["payment_id"].startswith("stripe_")
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy Field and Booking models
- switch field routes to use database CRUD
- update tests to reset database when exercising booking flow

## Testing
- `pytest backend/tests/test_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f2194f94832cb56628f109d00511