### PR TITLE
test: add frontend page tests

### DIFF
--- a/frontend/__tests__/fields.test.tsx
+++ b/frontend/__tests__/fields.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import FieldsPage from '../app/fields/page';
+import '@testing-library/jest-dom';
+
+test('renders fields and books a field', async () => {
+  const fetchMock = jest
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: 1, name: 'Field A', location: 'City', price_per_hour: 50 },
+      ],
+    })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+  global.fetch = fetchMock;
+  window.alert = jest.fn();
+
+  render(<FieldsPage />);
+
+  await waitFor(() => {
+    expect(screen.getByText(/Field A/)).toBeInTheDocument();
+  });
+  expect(fetchMock).toHaveBeenCalledWith('/api/fields');
+
+  fireEvent.click(screen.getByText('Reservar'));
+
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  expect(fetchMock).toHaveBeenLastCalledWith(
+    '/api/fields/1/bookings',
+    expect.objectContaining({ method: 'POST' })
+  );
+  expect(window.alert).toHaveBeenCalled();
+
+  (global.fetch as jest.Mock).mockRestore?.();
+  (window.alert as jest.Mock).mockRestore?.();
+});

--- a/frontend/__tests__/ranking.test.tsx
+++ b/frontend/__tests__/ranking.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import RankingPage from '../app/ranking';
+import '@testing-library/jest-dom';
+
+test('renders ranking fetched from API', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => [
+      { team: 'Team A', played: 10, wins: 5, draws: 3, losses: 2, goals_for: 20, goals_against: 10, goal_difference: 10, points: 18 },
+      { team: 'Team B', played: 10, wins: 4, draws: 4, losses: 2, goals_for: 15, goals_against: 12, goal_difference: 3, points: 16 },
+    ],
+  });
+
+  render(<RankingPage />);
+  expect(screen.getByText('Ranking')).toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(screen.getByText('Team A')).toBeInTheDocument();
+    expect(screen.getByText('Team B')).toBeInTheDocument();
+  });
+
+  expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/ranking');
+
+  (global.fetch as jest.Mock).mockRestore?.();
+});

--- a/frontend/__tests__/referees.test.tsx
+++ b/frontend/__tests__/referees.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import RefereesPage from '../app/referees/page';
+import '@testing-library/jest-dom';
+
+test('renders referees and adds a new referee', async () => {
+  const fetchMock = jest
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: 1, name: 'Ref A', level: 'regional' },
+      ],
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 2, name: 'Ref B', level: 'senior' }),
+    });
+
+  global.fetch = fetchMock;
+
+  render(<RefereesPage />);
+
+  await waitFor(() => {
+    expect(screen.getByText('Ref A - regional')).toBeInTheDocument();
+  });
+  expect(fetchMock).toHaveBeenCalledWith('/api/referees');
+
+  fireEvent.change(screen.getByPlaceholderText('Name'), {
+    target: { value: 'Ref B' },
+  });
+  fireEvent.change(screen.getByDisplayValue('Regional'), {
+    target: { value: 'senior' },
+  });
+  fireEvent.click(screen.getByText('Add'));
+
+  await waitFor(() => {
+    expect(screen.getByText('Ref B - senior')).toBeInTheDocument();
+  });
+  expect(fetchMock).toHaveBeenLastCalledWith(
+    '/api/referees',
+    expect.objectContaining({ method: 'POST' })
+  );
+
+  (global.fetch as jest.Mock).mockRestore?.();
+});


### PR DESCRIPTION
## Summary
- add tests for ranking page rendering and fetch call
- cover fields page loading and booking interactions
- test referees page listing and creation logic

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f21b634c832c974e55358e953940