### PR TITLE
Persist referee data with SQLAlchemy

### DIFF
--- a/backend/models/referees.py
+++ b/backend/models/referees.py
@@ -1,26 +1,77 @@
-"""Domain models for referee management."""
+"""Database models for referee management and scheduling."""
 from __future__ import annotations
 
 from datetime import date as Date
+
 from pydantic import BaseModel
+from sqlalchemy import Column, Date as SA_Date, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from . import Base
 
 
-class Referee(BaseModel):
-    """Represents a match official."""
-    id: int
-    name: str
-    level: str = "regional"
+class Referee(Base):
+    """Referee persisted in the database."""
+
+    __tablename__ = "referees"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    level = Column(String, nullable=False, default="regional")
+
+    availability = relationship(
+        "Availability", back_populates="referee", cascade="all, delete-orphan"
+    )
 
 
-class Availability(BaseModel):
-    """Availability entry for a referee on a given date."""
-    referee_id: int
-    date: Date
+class Availability(Base):
+    """Availability entry for a referee on a specific date."""
+
+    __tablename__ = "availability"
+
+    referee_id = Column(
+        Integer, ForeignKey("referees.id", ondelete="CASCADE"), primary_key=True
+    )
+    date = Column(SA_Date, primary_key=True)
+
+    referee = relationship("Referee", back_populates="availability")
 
 
 class Match(BaseModel):
     """Simplified match representation with assigned referee."""
+
     home: str
     away: str
     date: Date
     referee_id: int | None = None
+
+
+class RefereeSchema(BaseModel):
+    """Pydantic schema for serialising referees."""
+
+    id: int
+    name: str
+    level: str
+
+    class Config:
+        orm_mode = True
+
+
+class AvailabilitySchema(BaseModel):
+    """Pydantic schema for serialising availability entries."""
+
+    referee_id: int
+    date: Date
+
+    class Config:
+        orm_mode = True
+
+
+__all__ = [
+    "Referee",
+    "Availability",
+    "Match",
+    "RefereeSchema",
+    "AvailabilitySchema",
+]
+

--- a/backend/tests/test_referees.py
+++ b/backend/tests/test_referees.py
@@ -3,10 +3,16 @@ from datetime import date
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from backend.models import Base, engine
 from backend.routes.referees import router
 
 app = FastAPI()
 app.include_router(router)
+
+
+def setup_module(module):
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
 
 
 def test_referee_crud_flow():
@@ -26,6 +32,7 @@ def test_referee_crud_flow():
     # delete
     assert client.delete(f"/referees/{rid}").status_code == 200
     assert client.get(f"/referees/{rid}").status_code == 404
+    assert client.get("/referees").json() == []
 
 
 def test_schedule_with_availability():
@@ -34,6 +41,9 @@ def test_schedule_with_availability():
     rid = client.post("/referees", json={"name": "Luis"}).json()["id"]
     avail_date = date(2024, 1, 1).isoformat()
     client.post(f"/referees/{rid}/availability", json={"date": avail_date})
+    assert client.get(f"/referees/{rid}/availability").json() == [
+        {"referee_id": rid, "date": avail_date}
+    ]
     # plan match
     resp = client.post(
         "/referees/schedule",
@@ -42,3 +52,5 @@ def test_schedule_with_availability():
     assert resp.status_code == 200
     assigned = resp.json()[0]
     assert assigned["referee_id"] == rid
+    assert client.get(f"/referees/{rid}/availability").json() == []
+


### PR DESCRIPTION
## Summary
- model referees and availability tables with SQLAlchemy
- switch referee routes to database-backed CRUD and scheduling
- extend tests to cover referee persistence

## Testing
- `pytest backend/tests/test_referees.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f21aa584832c8fffd755705654b0