### PR TITLE
Use database-stored matches to build ranking table

### DIFF
--- a/backend/models/matches.py
+++ b/backend/models/matches.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String
+
+from . import Base
+
+
+class Match(Base):
+    """Persistent match representation used for ranking calculations."""
+
+    __tablename__ = "matches"
+
+    id = Column(Integer, primary_key=True, index=True)
+    home = Column(String, nullable=False)
+    away = Column(String, nullable=False)
+    home_goals = Column(Integer, nullable=False)
+    away_goals = Column(Integer, nullable=False)

--- a/backend/routes/ranking.py
+++ b/backend/routes/ranking.py
@@ -1,11 +1,24 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
 
-from ..services.ranking import SAMPLE_MATCHES, calculate_ranking
+from ..models import Base, SessionLocal, engine
+from ..services.ranking import get_ranking as compute_ranking
 
 router = APIRouter()
 
+# Ensure tables exist
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
 
 @router.get("/ranking")
-def get_ranking():
+def get_ranking(db: Session = Depends(get_db)):
     """Expose ranking computed from tournament results."""
-    return calculate_ranking(SAMPLE_MATCHES)
+    return compute_ranking(db)

--- a/backend/tests/test_ranking.py
+++ b/backend/tests/test_ranking.py
@@ -2,16 +2,40 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from backend.routes.ranking import router
+from backend.models import Base, engine, SessionLocal
+from backend.models.matches import Match
 
 app = FastAPI()
 app.include_router(router)
 
 
+def setup_module(module):
+    # Reset database for tests
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+
+def _insert_sample_matches():
+    db = SessionLocal()
+    db.add_all(
+        [
+            Match(home="Team A", away="Team B", home_goals=2, away_goals=1),
+            Match(home="Team C", away="Team A", home_goals=0, away_goals=3),
+            Match(home="Team B", away="Team C", home_goals=1, away_goals=1),
+        ]
+    )
+    db.commit()
+    db.close()
+
+
 def test_ranking_endpoint_returns_sorted_table():
+    _insert_sample_matches()
     client = TestClient(app)
     resp = client.get("/ranking")
     assert resp.status_code == 200
     table = resp.json()
-    assert len(table) > 0
-    points = [row["points"] for row in table]
-    assert points == sorted(points, reverse=True)
+    assert len(table) == 3
+    assert table[0]["team"] == "Team A"
+    assert table[0]["points"] == 6
+    assert table[1]["team"] == "Team B"
+    assert table[2]["team"] == "Team C"


### PR DESCRIPTION
## Summary
- add persistent `Match` model for results storage
- compute ranking table from DB records instead of hardcoded samples
- test ranking endpoint with inserted match data

## Testing
- `pytest backend/tests/test_ranking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f21ccf90832c89ab06cc89a5d3e0