### PR TITLE
Add SQLAlchemy stats aggregates and tests

### DIFF
--- a/backend/models/players.py
+++ b/backend/models/players.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String
+
+from . import Base
+
+
+class Player(Base):
+    """Persistent player statistics for leaderboard calculations."""
+
+    __tablename__ = "players"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    team = Column(String, nullable=False)
+    goals = Column(Integer, default=0, nullable=False)
+    assists = Column(Integer, default=0, nullable=False)

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -1,24 +1,51 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..models import Base, SessionLocal, engine
+from ..models.matches import Match
+from ..models.players import Player
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 
+# Ensure tables exist for stats routes
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
 
 @router.get("/summary")
-def get_summary_stats():
+def get_summary_stats(db: Session = Depends(get_db)):
     """Return consolidated summary statistics for the dashboard."""
+    total_teams = db.query(func.count(func.distinct(Player.team))).scalar() or 0
+    total_players = db.query(func.count(Player.id)).scalar() or 0
+    total_matches = db.query(func.count(Match.id)).scalar() or 0
+    total_goals = db.query(func.coalesce(func.sum(Match.home_goals + Match.away_goals), 0)).scalar()
+    avg_goals_per_match = total_goals / total_matches if total_matches else 0
+
     return {
-        "total_teams": 12,
-        "total_players": 240,
-        "total_matches": 66,
-        "avg_goals_per_match": 3.2,
+        "total_teams": total_teams,
+        "total_players": total_players,
+        "total_matches": total_matches,
+        "avg_goals_per_match": avg_goals_per_match,
     }
 
 
 @router.get("/players/top")
-def get_top_players():
+def get_top_players(db: Session = Depends(get_db)):
     """Return top players ordered by goals scored."""
+    players = (
+        db.query(Player)
+        .order_by(Player.goals.desc())
+        .limit(10)
+        .all()
+    )
     return [
-        {"player": "Juan Pérez", "goals": 12, "assists": 5},
-        {"player": "Carlos Gómez", "goals": 10, "assists": 7},
-        {"player": "Luis Rodríguez", "goals": 9, "assists": 4},
+        {"player": p.name, "goals": p.goals, "assists": p.assists} for p in players
     ]

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,25 +1,57 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+import pytest
 
 from backend.routes.stats import router
+from backend.models import Base, engine, SessionLocal
+from backend.models.players import Player
+from backend.models.matches import Match
 
 app = FastAPI()
 app.include_router(router)
 
 
+def _setup_sample_data():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    db.add_all(
+        [
+            Player(name="Juan Pérez", team="Team A", goals=12, assists=5),
+            Player(name="Carlos Gómez", team="Team B", goals=10, assists=7),
+            Player(name="Luis Rodríguez", team="Team C", goals=9, assists=4),
+        ]
+    )
+    db.add_all(
+        [
+            Match(home="Team A", away="Team B", home_goals=2, away_goals=1),
+            Match(home="Team C", away="Team A", home_goals=0, away_goals=3),
+            Match(home="Team B", away="Team C", home_goals=1, away_goals=1),
+        ]
+    )
+    db.commit()
+    db.close()
+
+
 def test_get_summary_stats():
+    _setup_sample_data()
     client = TestClient(app)
     resp = client.get("/stats/summary")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["total_teams"] == 12
-    assert data["avg_goals_per_match"] == 3.2
+    assert data["total_teams"] == 3
+    assert data["total_players"] == 3
+    assert data["total_matches"] == 3
+    assert data["avg_goals_per_match"] == pytest.approx(8 / 3)
 
 
 def test_get_top_players():
+    _setup_sample_data()
     client = TestClient(app)
     resp = client.get("/stats/players/top")
     assert resp.status_code == 200
     data = resp.json()
-    assert isinstance(data, list)
-    assert data[0]["goals"] >= data[1]["goals"]
+    assert len(data) == 3
+    assert data[0]["player"] == "Juan Pérez"
+    assert data[0]["goals"] == 12
+    assert data[0]["goals"] >= data[1]["goals"] >= data[2]["goals"]


### PR DESCRIPTION
## Summary
- add Player model for storing player stats
- derive summary metrics and top players using SQLAlchemy queries
- test stats endpoints with sample data

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b704205a54832c9f3ab460d03b1e1e