### PR TITLE
feat: use API base URL from env

### DIFF
--- a/frontend/__tests__/messages.test.tsx
+++ b/frontend/__tests__/messages.test.tsx
@@ -3,6 +3,7 @@ import MessagesPage from '../app/messages/page';
 import '@testing-library/jest-dom';
 
 test('renders messages fetched from API', async () => {
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => [
@@ -18,6 +19,8 @@ test('renders messages fetched from API', async () => {
     expect(screen.getByText(/Alice/)).toBeInTheDocument();
     expect(screen.getByText(/Bob/)).toBeInTheDocument();
   });
+
+  expect(global.fetch).toHaveBeenCalledWith(`${process.env.NEXT_PUBLIC_API_URL}/conversations/1/messages`);
 
   (global.fetch as jest.Mock).mockRestore?.();
 });

--- a/frontend/__tests__/ranking.test.tsx
+++ b/frontend/__tests__/ranking.test.tsx
@@ -3,6 +3,7 @@ import RankingPage from '../app/ranking';
 import '@testing-library/jest-dom';
 
 test('renders ranking fetched from API', async () => {
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => [
@@ -19,7 +20,7 @@ test('renders ranking fetched from API', async () => {
     expect(screen.getByText('Team B')).toBeInTheDocument();
   });
 
-  expect(global.fetch).toHaveBeenCalledWith('http://localhost:8000/ranking');
+  expect(global.fetch).toHaveBeenCalledWith(`${process.env.NEXT_PUBLIC_API_URL}/ranking`);
 
   (global.fetch as jest.Mock).mockRestore?.();
 });

--- a/frontend/app/messages/page.tsx
+++ b/frontend/app/messages/page.tsx
@@ -12,10 +12,11 @@ interface Message {
 export default function MessagesPage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
 
   async function fetchMessages() {
     try {
-      const res = await fetch("http://localhost:8000/conversations/1/messages");
+      const res = await fetch(`${baseUrl}/conversations/1/messages`);
       if (res.ok) {
         const data = await res.json();
         setMessages(data);
@@ -33,7 +34,7 @@ export default function MessagesPage() {
 
   async function sendMessage() {
     if (!input) return;
-    await fetch("http://localhost:8000/conversations/1/messages", {
+    await fetch(`${baseUrl}/conversations/1/messages`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ sender: "User", content: input }),

--- a/frontend/app/ranking.tsx
+++ b/frontend/app/ranking.tsx
@@ -17,7 +17,8 @@ export default function RankingPage() {
   const [rows, setRows] = useState<TeamRow[]>([]);
 
   useEffect(() => {
-    fetch('http://localhost:8000/ranking')
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+    fetch(`${baseUrl}/ranking`)
       .then((res) => res.json())
       .then(setRows)
       .catch(console.error);


### PR DESCRIPTION
## Summary
- read backend base URL from NEXT_PUBLIC_API_URL in ranking and messages pages
- update tests to configure environment variable and assert fetch calls use it

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7041fac74832ca48791379b5e829d