### PR TITLE
Use base API URL for fields and referees

### DIFF
--- a/frontend/__tests__/fields.test.tsx
+++ b/frontend/__tests__/fields.test.tsx
@@ -3,6 +3,7 @@ import FieldsPage from '../app/fields/page';
 import '@testing-library/jest-dom';
 
 test('renders fields and books a field', async () => {
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
   const fetchMock = jest
     .fn()
     .mockResolvedValueOnce({
@@ -21,13 +22,15 @@ test('renders fields and books a field', async () => {
   await waitFor(() => {
     expect(screen.getByText(/Field A/)).toBeInTheDocument();
   });
-  expect(fetchMock).toHaveBeenCalledWith('/api/fields');
+  expect(fetchMock).toHaveBeenCalledWith(
+    `${process.env.NEXT_PUBLIC_API_URL}/fields`
+  );
 
   fireEvent.click(screen.getByText('Reservar'));
 
   await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   expect(fetchMock).toHaveBeenLastCalledWith(
-    '/api/fields/1/bookings',
+    `${process.env.NEXT_PUBLIC_API_URL}/fields/1/bookings`,
     expect.objectContaining({ method: 'POST' })
   );
   expect(window.alert).toHaveBeenCalled();

--- a/frontend/__tests__/referees.test.tsx
+++ b/frontend/__tests__/referees.test.tsx
@@ -3,6 +3,7 @@ import RefereesPage from '../app/referees/page';
 import '@testing-library/jest-dom';
 
 test('renders referees and adds a new referee', async () => {
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
   const fetchMock = jest
     .fn()
     .mockResolvedValueOnce({
@@ -23,7 +24,9 @@ test('renders referees and adds a new referee', async () => {
   await waitFor(() => {
     expect(screen.getByText('Ref A - regional')).toBeInTheDocument();
   });
-  expect(fetchMock).toHaveBeenCalledWith('/api/referees');
+  expect(fetchMock).toHaveBeenCalledWith(
+    `${process.env.NEXT_PUBLIC_API_URL}/referees`
+  );
 
   fireEvent.change(screen.getByPlaceholderText('Name'), {
     target: { value: 'Ref B' },
@@ -37,7 +40,7 @@ test('renders referees and adds a new referee', async () => {
     expect(screen.getByText('Ref B - senior')).toBeInTheDocument();
   });
   expect(fetchMock).toHaveBeenLastCalledWith(
-    '/api/referees',
+    `${process.env.NEXT_PUBLIC_API_URL}/referees`,
     expect.objectContaining({ method: 'POST' })
   );
 

--- a/frontend/app/fields/page.tsx
+++ b/frontend/app/fields/page.tsx
@@ -12,17 +12,18 @@ interface Field {
 export default function FieldsPage() {
   const [fields, setFields] = useState<Field[]>([])
   const [provider, setProvider] = useState('stripe')
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL
 
   useEffect(() => {
-    fetch('/api/fields')
+    fetch(`${baseUrl}/fields`)
       .then(res => res.json())
       .then(setFields)
-  }, [])
+  }, [baseUrl])
 
   async function book(fieldId: number) {
     const now = new Date()
     const end = new Date(now.getTime() + 60 * 60 * 1000)
-    await fetch(`/api/fields/${fieldId}/bookings`, {
+    await fetch(`${baseUrl}/fields/${fieldId}/bookings`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/frontend/app/referees/page.tsx
+++ b/frontend/app/referees/page.tsx
@@ -12,16 +12,17 @@ export default function RefereesPage() {
   const [refs, setRefs] = useState<Referee[]>([])
   const [name, setName] = useState('')
   const [level, setLevel] = useState('regional')
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL
 
   useEffect(() => {
-    fetch('/api/referees')
+    fetch(`${baseUrl}/referees`)
       .then(res => res.json())
       .then(setRefs)
-  }, [])
+  }, [baseUrl])
 
   async function addReferee(e: React.FormEvent) {
     e.preventDefault()
-    const res = await fetch('/api/referees', {
+    const res = await fetch(`${baseUrl}/referees`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, level })


### PR DESCRIPTION
## Summary
- read NEXT_PUBLIC_API_URL in fields and referees pages
- prefix API calls with configured base URL
- update tests to expect calls to base URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b706cc0e14832c89d36fd1cfad3903