### PR TITLE
feat: allow selecting and creating conversations in messages page

### DIFF
--- a/frontend/__tests__/messages.test.tsx
+++ b/frontend/__tests__/messages.test.tsx
@@ -1,16 +1,31 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MessagesPage from '../app/messages/page';
 import '@testing-library/jest-dom';
 
-test('renders messages fetched from API', async () => {
+test('renders messages for initial conversation', async () => {
   process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
-  global.fetch = jest.fn().mockResolvedValue({
-    ok: true,
-    json: async () => [
-      { id: 1, sender: 'Alice', content: 'Hola', timestamp: '' },
-      { id: 2, sender: 'Bob', content: 'Qué tal', timestamp: '' },
-    ],
+  const fetchMock = jest.fn((url: string) => {
+    if (url === `${process.env.NEXT_PUBLIC_API_URL}/conversations`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { id: 1, title: 'Chat 1' },
+          { id: 2, title: 'Chat 2' },
+        ],
+      });
+    }
+    if (url === `${process.env.NEXT_PUBLIC_API_URL}/conversations/1/messages`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { id: 1, sender: 'Alice', content: 'Hola', timestamp: '' },
+          { id: 2, sender: 'Bob', content: 'Qué tal', timestamp: '' },
+        ],
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
   });
+  global.fetch = fetchMock as any;
 
   render(<MessagesPage />);
   expect(screen.getByText('Messages')).toBeInTheDocument();
@@ -20,7 +35,61 @@ test('renders messages fetched from API', async () => {
     expect(screen.getByText(/Bob/)).toBeInTheDocument();
   });
 
-  expect(global.fetch).toHaveBeenCalledWith(`${process.env.NEXT_PUBLIC_API_URL}/conversations/1/messages`);
+  expect(fetchMock).toHaveBeenCalledWith(`${process.env.NEXT_PUBLIC_API_URL}/conversations`);
+  expect(fetchMock).toHaveBeenCalledWith(
+    `${process.env.NEXT_PUBLIC_API_URL}/conversations/1/messages`
+  );
+
+  (global.fetch as jest.Mock).mockRestore?.();
+});
+
+test('fetches messages for selected conversation', async () => {
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
+  const fetchMock = jest.fn((url: string) => {
+    if (url === `${process.env.NEXT_PUBLIC_API_URL}/conversations`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { id: 1, title: 'Chat 1' },
+          { id: 2, title: 'Chat 2' },
+        ],
+      });
+    }
+    if (url === `${process.env.NEXT_PUBLIC_API_URL}/conversations/1/messages`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { id: 1, sender: 'Alice', content: 'Hola', timestamp: '' },
+        ],
+      });
+    }
+    if (url === `${process.env.NEXT_PUBLIC_API_URL}/conversations/2/messages`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { id: 3, sender: 'Carol', content: 'Hi', timestamp: '' },
+        ],
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  global.fetch = fetchMock as any;
+
+  render(<MessagesPage />);
+
+  await waitFor(() => screen.getByText(/Hola/));
+
+  fireEvent.change(screen.getByLabelText('conversation'), {
+    target: { value: '2' },
+  });
+
+  await waitFor(() => {
+    expect(screen.getByText(/Carol/)).toBeInTheDocument();
+  });
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    `${process.env.NEXT_PUBLIC_API_URL}/conversations/2/messages`
+  );
 
   (global.fetch as jest.Mock).mockRestore?.();
 });

--- a/frontend/app/messages/page.tsx
+++ b/frontend/app/messages/page.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useState } from "react";
 
+interface Conversation {
+  id: number;
+  title: string | null;
+}
+
 interface Message {
   id: number;
   sender: string;
@@ -10,13 +15,36 @@ interface Message {
 }
 
 export default function MessagesPage() {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<number | null>(
+    null
+  );
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
+  const [newTitle, setNewTitle] = useState("");
   const baseUrl = process.env.NEXT_PUBLIC_API_URL;
 
-  async function fetchMessages() {
+  async function fetchConversations() {
     try {
-      const res = await fetch(`${baseUrl}/conversations/1/messages`);
+      const res = await fetch(`${baseUrl}/conversations`);
+      if (res.ok) {
+        const data = await res.json();
+        setConversations(data);
+        if (data.length > 0 && !activeConversationId) {
+          setActiveConversationId(data[0].id);
+        }
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function fetchMessages() {
+    if (!activeConversationId) return;
+    try {
+      const res = await fetch(
+        `${baseUrl}/conversations/${activeConversationId}/messages`
+      );
       if (res.ok) {
         const data = await res.json();
         setMessages(data);
@@ -27,14 +55,20 @@ export default function MessagesPage() {
   }
 
   useEffect(() => {
+    fetchConversations();
+  }, []);
+
+  useEffect(() => {
+    if (!activeConversationId) return;
     fetchMessages();
     const interval = setInterval(fetchMessages, 5000);
     return () => clearInterval(interval);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeConversationId]);
 
   async function sendMessage() {
-    if (!input) return;
-    await fetch(`${baseUrl}/conversations/1/messages`, {
+    if (!input || !activeConversationId) return;
+    await fetch(`${baseUrl}/conversations/${activeConversationId}/messages`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ sender: "User", content: input }),
@@ -43,9 +77,47 @@ export default function MessagesPage() {
     fetchMessages();
   }
 
+  async function createConversation() {
+    const res = await fetch(`${baseUrl}/conversations`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: newTitle || null }),
+    });
+    if (res.ok) {
+      const convo = await res.json();
+      setConversations((prev) => [...prev, convo]);
+      setActiveConversationId(convo.id);
+      setNewTitle("");
+    }
+  }
+
   return (
     <div>
       <h1>Messages</h1>
+      <div>
+        <label>
+          Conversation:
+          <select
+            aria-label="conversation"
+            value={activeConversationId ?? ""}
+            onChange={(e) => setActiveConversationId(Number(e.target.value))}
+          >
+            {conversations.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.title || `Conversation ${c.id}`}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div>
+        <input
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          placeholder="New conversation title"
+        />
+        <button onClick={createConversation}>Create</button>
+      </div>
       <ul>
         {messages.map((m) => (
           <li key={m.id}>


### PR DESCRIPTION
## Summary
- list and select conversations on messages page
- add ability to create new conversations
- test conversation selection workflow

## Testing
- `cd frontend && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b706cc6c48832ca95b3c2fa961f01b