### PR TITLE
Use env API URL in advanced dashboard and adjust tests

### DIFF
--- a/frontend/__tests__/advanced.test.tsx
+++ b/frontend/__tests__/advanced.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+
+jest.mock(
+  'recharts',
+  () => ({
+    LineChart: () => null,
+    Line: () => null,
+    CartesianGrid: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    Tooltip: () => null,
+    BarChart: () => null,
+    Bar: () => null,
+  }),
+  { virtual: true }
+);
+
+import AdvancedDashboard from '../app/dashboard/advanced';
+
+test('fetches stats from configured API', async () => {
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
+  const fetchMock = jest.fn((url: RequestInfo) => {
+    if (url === `${process.env.NEXT_PUBLIC_API_URL}/stats/summary`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          total_teams: 1,
+          total_players: 2,
+          total_matches: 3,
+          avg_goals_per_match: 1.5,
+        }),
+      });
+    }
+    if (url === `${process.env.NEXT_PUBLIC_API_URL}/stats/players/top`) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { player: 'Alice', goals: 5, assists: 2 },
+        ],
+      });
+    }
+    return Promise.reject(new Error('unknown url'));
+  });
+
+  global.fetch = fetchMock as any;
+
+  render(<AdvancedDashboard />);
+  expect(screen.getByText('Advanced Stats')).toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${process.env.NEXT_PUBLIC_API_URL}/stats/summary`
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${process.env.NEXT_PUBLIC_API_URL}/stats/players/top`
+    );
+  });
+
+  (global.fetch as jest.Mock).mockRestore?.();
+});

--- a/frontend/app/dashboard/advanced.tsx
+++ b/frontend/app/dashboard/advanced.tsx
@@ -27,16 +27,17 @@ interface PlayerStat {
 export default function AdvancedDashboard() {
   const [summary, setSummary] = useState<Summary | null>(null);
   const [players, setPlayers] = useState<PlayerStat[]>([]);
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
 
   useEffect(() => {
-    fetch('/api/stats/summary')
+    fetch(`${baseUrl}/stats/summary`)
       .then(res => res.json())
       .then(setSummary);
 
-    fetch('/api/stats/players/top')
+    fetch(`${baseUrl}/stats/players/top`)
       .then(res => res.json())
       .then(setPlayers);
-  }, []);
+  }, [baseUrl]);
 
   return (
     <div className="p-4 space-y-8">

--- a/frontend/recharts.d.ts
+++ b/frontend/recharts.d.ts
@@ -1,0 +1,1 @@
+declare module 'recharts';


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` in advanced dashboard fetches
- add tests for advanced dashboard and mock Recharts
- declare Recharts module for TypeScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b70b9799f4832cbec3ad391158fcf2