### PR TITLE
Add conversations list endpoint with tests

### DIFF
--- a/backend/routes/messages.py
+++ b/backend/routes/messages.py
@@ -30,6 +30,12 @@ def create_conversation(conversation: ConversationCreate, db: Session = Depends(
     return {"id": convo.id, "title": convo.title}
 
 
+@router.get("/conversations")
+def list_conversations(db: Session = Depends(get_db)):
+    convos = db.query(Conversation).order_by(Conversation.id).all()
+    return [{"id": c.id, "title": c.title} for c in convos]
+
+
 class MessageCreate(BaseModel):
     sender: str
     content: str

--- a/backend/tests/test_messages.py
+++ b/backend/tests/test_messages.py
@@ -40,3 +40,24 @@ def test_message_flow():
     assert len(messages) == 2
     assert messages[0]["content"] == "Hola"
     assert messages[1]["sender"] == "Bob"
+
+
+def test_list_conversations():
+    run_migrations()
+    client = TestClient(app)
+
+    r0 = client.get("/conversations")
+    assert r0.status_code == 200
+    assert r0.json() == []
+
+    c1 = client.post("/conversations", json={"title": "General"})
+    assert c1.status_code == 200
+    c2 = client.post("/conversations", json={"title": "Random"})
+    assert c2.status_code == 200
+
+    r1 = client.get("/conversations")
+    assert r1.status_code == 200
+    convos = r1.json()
+    assert len(convos) == 2
+    titles = {c["title"] for c in convos}
+    assert {"General", "Random"} <= titles

--- a/frontend/app/messages/page.tsx
+++ b/frontend/app/messages/page.tsx
@@ -102,11 +102,17 @@ export default function MessagesPage() {
             value={activeConversationId ?? ""}
             onChange={(e) => setActiveConversationId(Number(e.target.value))}
           >
-            {conversations.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.title || `Conversation ${c.id}`}
+            {conversations.length === 0 ? (
+              <option value="" disabled>
+                No conversations
               </option>
-            ))}
+            ) : (
+              conversations.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.title || `Conversation ${c.id}`}
+                </option>
+              ))
+            )}
           </select>
         </label>
       </div>


### PR DESCRIPTION
## Summary
- add GET `/conversations` endpoint to list all conversations
- cover conversation listing with backend test
- handle empty conversation lists in Messages page

## Testing
- `pytest backend/tests/test_messages.py`
- `cd frontend && npm test -- --runTestsByPath __tests__/messages.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b70b996a60832ca19ceaa13943396d