### PR TITLE
test: stub payment SDKs

### DIFF
--- a/backend/tests/test_payments.py
+++ b/backend/tests/test_payments.py
@@ -1,7 +1,23 @@
+import sys
 import types
 from unittest.mock import Mock
-import mercadopago
-import stripe
+
+# The payments tests run without the real Stripe and MercadoPago SDKs. When
+# those packages are missing we insert small stand-ins into ``sys.modules`` so
+# that the production code can import and monkeypatch them normally.
+try:  # pragma: no cover - executed only when SDKs are missing
+    import stripe  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    stripe = types.SimpleNamespace(
+        PaymentIntent=types.SimpleNamespace(create=lambda *a, **k: None)
+    )
+    sys.modules["stripe"] = stripe  # type: ignore
+
+try:  # pragma: no cover - executed only when SDKs are missing
+    import mercadopago  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    mercadopago = types.SimpleNamespace(SDK=object)
+    sys.modules["mercadopago"] = mercadopago  # type: ignore
 
 from backend.core.payments import process_payment
 


### PR DESCRIPTION
## Summary
- stub stripe and MercadoPago modules when SDKs are missing so payments tests run without real packages
- document how payment dependencies are simulated in tests

## Testing
- `pytest backend/tests/test_payments.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70b9a6d94832c9beec0fda25f1a66