### PR TITLE
Use configurable API URL for referee scheduling

### DIFF
--- a/frontend/__tests__/assignReferees.test.tsx
+++ b/frontend/__tests__/assignReferees.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import AssignRefereesPage from '../app/referees/assign/page'
+
+test('schedules referees using configured API', async () => {
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000'
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true })
+  })
+  global.fetch = fetchMock as any
+
+  render(<AssignRefereesPage />)
+
+  fireEvent.change(screen.getByPlaceholderText('Home'), {
+    target: { value: 'Team A' }
+  })
+  fireEvent.change(screen.getByPlaceholderText('Away'), {
+    target: { value: 'Team B' }
+  })
+  fireEvent.click(screen.getByText('Schedule'))
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${process.env.NEXT_PUBLIC_API_URL}/referees/schedule`,
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  ;(global.fetch as jest.Mock).mockRestore?.()
+})

--- a/frontend/app/referees/assign/page.tsx
+++ b/frontend/app/referees/assign/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 
 export default function AssignRefereesPage() {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL
   const [home, setHome] = useState('')
   const [away, setAway] = useState('')
   const [date, setDate] = useState('')
@@ -10,7 +11,7 @@ export default function AssignRefereesPage() {
 
   async function schedule(e: React.FormEvent) {
     e.preventDefault()
-    const res = await fetch('/api/referees/schedule', {
+    const res = await fetch(`${baseUrl}/referees/schedule`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify([{ home, away, date }])


### PR DESCRIPTION
## Summary
- read `NEXT_PUBLIC_API_URL` at start of assign referees component
- call `/referees/schedule` via full API base URL
- add unit test ensuring fetch uses configured base URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b70eb1bb90832c840a560ff1f7400c