### PR TITLE
Validate booking conflicts

### DIFF
--- a/backend/routes/fields.py
+++ b/backend/routes/fields.py
@@ -74,6 +74,17 @@ def book_field(
     field = db.get(FieldModel, field_id)
     if not field:
         raise HTTPException(status_code=404, detail="Field not found")
+    conflict = (
+        db.query(BookingModel)
+        .filter(
+            BookingModel.field_id == field_id,
+            BookingModel.start_time < payload.end_time,
+            BookingModel.end_time > payload.start_time,
+        )
+        .first()
+    )
+    if conflict:
+        raise HTTPException(status_code=400, detail="Field already booked for this time")
     payment_id = process_payment(payload.provider, field.price_per_hour)
     booking = BookingModel(
         field_id=field_id,

--- a/backend/tests/test_fields.py
+++ b/backend/tests/test_fields.py
@@ -40,3 +40,29 @@ def test_field_booking_flow():
     assert booking["paid"] is True
     assert booking["payment_id"].startswith("stripe_")
 
+
+def test_booking_conflict_validation():
+    client = TestClient(app)
+    res = client.post(
+        "/fields",
+        json={"name": "Downtown", "location": "NYC", "price_per_hour": 75.0},
+    )
+    assert res.status_code == 200
+    field = res.json()
+
+    booking_payload = {
+        "start_time": "2024-02-01T10:00:00Z",
+        "end_time": "2024-02-01T11:00:00Z",
+        "provider": "stripe",
+    }
+    res = client.post(f"/fields/{field['id']}/bookings", json=booking_payload)
+    assert res.status_code == 200
+
+    overlapping_payload = {
+        "start_time": "2024-02-01T10:30:00Z",
+        "end_time": "2024-02-01T11:30:00Z",
+        "provider": "stripe",
+    }
+    res = client.post(f"/fields/{field['id']}/bookings", json=overlapping_payload)
+    assert res.status_code == 400
+


### PR DESCRIPTION
## Summary
- prevent overlapping field bookings
- test booking overlap validation

## Testing
- `pytest backend/tests/test_fields.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70eb257a8832cbb0eaada488a12f2