### PR TITLE
Validate API_FOOTBALL_KEY configuration and add test

### DIFF
--- a/backend/services/api_football.py
+++ b/backend/services/api_football.py
@@ -8,6 +8,8 @@ import requests
 
 API_FOOTBALL_HOST = os.getenv("API_FOOTBALL_HOST", "https://api-football-v1.p.rapidapi.com/v3")
 API_FOOTBALL_KEY = os.getenv("API_FOOTBALL_KEY", "")
+if not API_FOOTBALL_KEY:
+    raise RuntimeError("API_FOOTBALL_KEY environment variable must be set")
 
 
 def fetch_leagues(country: Optional[str] = None) -> Dict[str, Any]:

--- a/backend/tests/test_api_football.py
+++ b/backend/tests/test_api_football.py
@@ -1,11 +1,18 @@
+"""Tests for the API-Football service integration."""
 from fastapi.testclient import TestClient
-
-from backend.app.main import app
-from backend.services import api_football
+import pytest
+import sys
 
 
 def test_external_leagues(monkeypatch):
-    def fake_get(url, headers=None, params=None, timeout=None):
+    """Ensure the endpoint returns data when the API key is set."""
+    monkeypatch.setenv("API_FOOTBALL_KEY", "test-key")
+
+    # Import after setting the environment variable so the module loads correctly
+    from backend.app.main import app  # pylint: disable=import-error
+    import backend.services.api_football as api_football
+
+    def fake_get(url, headers=None, params=None, timeout=None):  # noqa: D401
         class FakeResp:
             def raise_for_status(self):
                 pass
@@ -20,3 +27,12 @@ def test_external_leagues(monkeypatch):
     resp = client.get("/external-leagues")
     assert resp.status_code == 200
     assert resp.json()["response"][0]["league"]["name"] == "Test League"
+
+
+def test_missing_api_key(monkeypatch):
+    """Module import should fail if the API key is absent."""
+    monkeypatch.delenv("API_FOOTBALL_KEY", raising=False)
+    sys.modules.pop("backend.services.api_football", None)
+    with pytest.raises(RuntimeError):
+        import backend.services.api_football  # noqa: F401, PTC-W003
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -49,9 +49,12 @@ Tanto la PWA como el cliente React Native pueden reutilizar los endpoints existe
 
 ## Variables de entorno
 
-Configura las credenciales necesarias para los proveedores de pago creando un archivo `.env` basado en `.env.example`:
+Configura las credenciales necesarias para los proveedores de pago y de la API de fútbol creando un archivo `.env` basado en `.env.example`.
+
+Sin `API_FOOTBALL_KEY` el backend no podrá comunicarse con la API externa y se detendrá al iniciar.
 
 ```bash
+API_FOOTBALL_KEY=tu_clave_de_api_football
 STRIPE_SECRET_KEY=sk_live_...
 STRIPE_PUBLIC_KEY=pk_live_...
 MERCADOPAGO_ACCESS_TOKEN=APP_USR-...


### PR DESCRIPTION
## Summary
- raise clear `RuntimeError` when `API_FOOTBALL_KEY` is missing
- document API key requirement for deployment
- add tests for API key presence and absence

## Testing
- `pytest backend/tests/test_api_football.py`

------
https://chatgpt.com/codex/tasks/task_e_68b70ecf6230832c8e20cc835e16823b