### PR TITLE
Persist scheduled matches

### DIFF
--- a/backend/alembic/versions/5c3b6f442e3e_create_referee_matches_table.py
+++ b/backend/alembic/versions/5c3b6f442e3e_create_referee_matches_table.py
@@ -1,0 +1,38 @@
+"""create referee_matches table
+
+Revision ID: 5c3b6f442e3e
+Revises: bd5ea3c7c478
+Create Date: 2025-09-02 16:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5c3b6f442e3e'
+down_revision: Union[str, Sequence[str], None] = 'bd5ea3c7c478'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create referee_matches table."""
+    op.create_table(
+        'referee_matches',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('home', sa.String(), nullable=False),
+        sa.Column('away', sa.String(), nullable=False),
+        sa.Column('date', sa.Date(), nullable=False),
+        sa.Column('referee_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['referee_id'], ['referees.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_referee_matches_id'), 'referee_matches', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    """Drop referee_matches table."""
+    op.drop_index(op.f('ix_referee_matches_id'), table_name='referee_matches')
+    op.drop_table('referee_matches')

--- a/backend/models/referees.py
+++ b/backend/models/referees.py
@@ -37,13 +37,31 @@ class Availability(Base):
     referee = relationship("Referee", back_populates="availability")
 
 
-class Match(BaseModel):
-    """Simplified match representation with assigned referee."""
+class Match(Base):
+    """Scheduled match with an assigned referee."""
 
+    __tablename__ = "referee_matches"
+
+    id = Column(Integer, primary_key=True, index=True)
+    home = Column(String, nullable=False)
+    away = Column(String, nullable=False)
+    date = Column(SA_Date, nullable=False)
+    referee_id = Column(Integer, ForeignKey("referees.id", ondelete="SET NULL"))
+
+    referee = relationship("Referee")
+
+
+class MatchSchema(BaseModel):
+    """Pydantic schema for serialising scheduled matches."""
+
+    id: int
     home: str
     away: str
     date: Date
     referee_id: int | None = None
+
+    class Config:
+        orm_mode = True
 
 
 class RefereeSchema(BaseModel):
@@ -71,6 +89,7 @@ __all__ = [
     "Referee",
     "Availability",
     "Match",
+    "MatchSchema",
     "RefereeSchema",
     "AvailabilitySchema",
 ]

--- a/backend/routes/referees.py
+++ b/backend/routes/referees.py
@@ -13,6 +13,7 @@ from ..models.referees import (
     Availability,
     AvailabilitySchema,
     Match,
+    MatchSchema,
     Referee,
     RefereeSchema,
 )
@@ -113,7 +114,7 @@ class MatchCreate(BaseModel):
     date: date
 
 
-@router.post("/schedule", response_model=List[Match])
+@router.post("/schedule", response_model=List[MatchSchema])
 def schedule_matches(
     matches: List[MatchCreate], db: Session = Depends(get_db)
 ) -> List[Match]:
@@ -130,6 +131,15 @@ def schedule_matches(
             )
         referee_id = avail.referee_id
         db.delete(avail)
-        db.commit()
-        assigned.append(Match(**match.dict(), referee_id=referee_id))
+        record = Match(
+            home=match.home,
+            away=match.away,
+            date=match.date,
+            referee_id=referee_id,
+        )
+        db.add(record)
+        assigned.append(record)
+    db.commit()
+    for m in assigned:
+        db.refresh(m)
     return assigned

--- a/backend/tests/test_referees.py
+++ b/backend/tests/test_referees.py
@@ -4,6 +4,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from backend.routes.referees import router
+from backend.models import SessionLocal
+from backend.models.referees import Match
 from . import run_migrations
 
 app = FastAPI()
@@ -52,4 +54,14 @@ def test_schedule_with_availability():
     assigned = resp.json()[0]
     assert assigned["referee_id"] == rid
     assert client.get(f"/referees/{rid}/availability").json() == []
+
+    db = SessionLocal()
+    stored = db.query(Match).all()
+    assert len(stored) == 1
+    persisted = stored[0]
+    assert persisted.home == "A"
+    assert persisted.away == "B"
+    assert persisted.referee_id == rid
+    assert persisted.date.isoformat() == avail_date
+    db.close()
 


### PR DESCRIPTION
## Summary
- add persistent Match model and migration to store scheduled matches
- schedule_matches now writes Match records in a single commit
- test covers database persistence of scheduled matches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70ebd42bc832c9e81ed9e31695169