### PR TITLE
test: centralize migrations and client fixture

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from . import run_migrations
+
+
+@pytest.fixture(autouse=True)
+def _run_migrations():
+    """Apply database migrations before each test."""
+    run_migrations()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Return a test client for the FastAPI app."""
+    os.environ.setdefault("API_FOOTBALL_KEY", "test-key")
+    from backend.app.main import app
+
+    return TestClient(app)

--- a/backend/tests/test_fields.py
+++ b/backend/tests/test_fields.py
@@ -1,20 +1,4 @@
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
-from backend.routes.fields import router
-from . import run_migrations
-
-app = FastAPI()
-app.include_router(router)
-
-
-def setup_module(module):
-    # Reset database for tests
-    run_migrations()
-
-
-def test_field_booking_flow():
-    client = TestClient(app)
+def test_field_booking_flow(client):
     # create field
     res = client.post(
         "/fields",
@@ -41,8 +25,7 @@ def test_field_booking_flow():
     assert booking["payment_id"].startswith("stripe_")
 
 
-def test_booking_conflict_validation():
-    client = TestClient(app)
+def test_booking_conflict_validation(client):
     res = client.post(
         "/fields",
         json={"name": "Downtown", "location": "NYC", "price_per_hour": 75.0},

--- a/backend/tests/test_messages.py
+++ b/backend/tests/test_messages.py
@@ -1,20 +1,4 @@
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
-from backend.routes.messages import router
-from . import run_migrations
-
-app = FastAPI()
-app.include_router(router)
-
-
-def setup_module(module):
-    # Reset database for tests
-    run_migrations()
-
-
-def test_message_flow():
-    client = TestClient(app)
+def test_message_flow(client):
     # Create conversation
     response = client.post("/conversations", json={"title": "General"})
     assert response.status_code == 200
@@ -42,10 +26,7 @@ def test_message_flow():
     assert messages[1]["sender"] == "Bob"
 
 
-def test_list_conversations():
-    run_migrations()
-    client = TestClient(app)
-
+def test_list_conversations(client):
     r0 = client.get("/conversations")
     assert r0.status_code == 200
     assert r0.json() == []

--- a/backend/tests/test_ranking.py
+++ b/backend/tests/test_ranking.py
@@ -1,18 +1,5 @@
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
-from backend.routes.ranking import router
 from backend.models import SessionLocal
-from . import run_migrations
 from backend.models.matches import Match
-
-app = FastAPI()
-app.include_router(router)
-
-
-def setup_module(module):
-    # Reset database for tests
-    run_migrations()
 
 
 def _insert_sample_matches():
@@ -28,9 +15,8 @@ def _insert_sample_matches():
     db.close()
 
 
-def test_ranking_endpoint_returns_sorted_table():
+def test_ranking_endpoint_returns_sorted_table(client):
     _insert_sample_matches()
-    client = TestClient(app)
     resp = client.get("/ranking")
     assert resp.status_code == 200
     table = resp.json()

--- a/backend/tests/test_referees.py
+++ b/backend/tests/test_referees.py
@@ -1,23 +1,10 @@
 from datetime import date
 
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
-from backend.routes.referees import router
 from backend.models import SessionLocal
 from backend.models.referees import Match
-from . import run_migrations
-
-app = FastAPI()
-app.include_router(router)
 
 
-def setup_module(module):
-    run_migrations()
-
-
-def test_referee_crud_flow():
-    client = TestClient(app)
+def test_referee_crud_flow(client):
     # create
     resp = client.post("/referees", json={"name": "Ana", "level": "senior"})
     assert resp.status_code == 200
@@ -36,8 +23,7 @@ def test_referee_crud_flow():
     assert client.get("/referees").json() == []
 
 
-def test_schedule_with_availability():
-    client = TestClient(app)
+def test_schedule_with_availability(client):
     # create referee and availability
     rid = client.post("/referees", json={"name": "Luis"}).json()["id"]
     avail_date = date(2024, 1, 1).isoformat()

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,19 +1,11 @@
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 import pytest
 
-from backend.routes.stats import router
 from backend.models import SessionLocal
 from backend.models.players import Player
 from backend.models.matches import Match
-from . import run_migrations
-
-app = FastAPI()
-app.include_router(router)
 
 
 def _setup_sample_data():
-    run_migrations()
     db = SessionLocal()
     db.add_all(
         [
@@ -33,9 +25,8 @@ def _setup_sample_data():
     db.close()
 
 
-def test_get_summary_stats():
+def test_get_summary_stats(client):
     _setup_sample_data()
-    client = TestClient(app)
     resp = client.get("/stats/summary")
     assert resp.status_code == 200
     data = resp.json()
@@ -45,9 +36,8 @@ def test_get_summary_stats():
     assert data["avg_goals_per_match"] == pytest.approx(8 / 3)
 
 
-def test_get_top_players():
+def test_get_top_players(client):
     _setup_sample_data()
-    client = TestClient(app)
     resp = client.get("/stats/players/top")
     assert resp.status_code == 200
     data = resp.json()


### PR DESCRIPTION
## Summary
- run migrations automatically through autouse fixture
- provide reusable TestClient fixture
- simplify tests by using shared client and removing setup hooks

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b72266c808832cb2f12ee93638635e