### PR TITLE
Check API key inside fetch_leagues

### DIFF
--- a/backend/services/api_football.py
+++ b/backend/services/api_football.py
@@ -6,10 +6,9 @@ from typing import Any, Dict, Optional
 
 import requests
 
-API_FOOTBALL_HOST = os.getenv("API_FOOTBALL_HOST", "https://api-football-v1.p.rapidapi.com/v3")
-API_FOOTBALL_KEY = os.getenv("API_FOOTBALL_KEY", "")
-if not API_FOOTBALL_KEY:
-    raise RuntimeError("API_FOOTBALL_KEY environment variable must be set")
+API_FOOTBALL_HOST = os.getenv(
+    "API_FOOTBALL_HOST", "https://api-football-v1.p.rapidapi.com/v3"
+)
 
 
 def fetch_leagues(country: Optional[str] = None) -> Dict[str, Any]:
@@ -25,7 +24,10 @@ def fetch_leagues(country: Optional[str] = None) -> Dict[str, Any]:
     dict
         Parsed JSON response from the API.
     """
-    headers = {"x-rapidapi-key": API_FOOTBALL_KEY}
+    api_key = os.getenv("API_FOOTBALL_KEY")
+    if not api_key:
+        raise RuntimeError("API_FOOTBALL_KEY environment variable must be set")
+    headers = {"x-rapidapi-key": api_key}
     params: Dict[str, Any] = {}
     if country:
         params["country"] = country

--- a/backend/tests/test_api_football.py
+++ b/backend/tests/test_api_football.py
@@ -1,14 +1,13 @@
 """Tests for the API-Football service integration."""
 from fastapi.testclient import TestClient
 import pytest
-import sys
 
 
 def test_external_leagues(monkeypatch):
     """Ensure the endpoint returns data when the API key is set."""
     monkeypatch.setenv("API_FOOTBALL_KEY", "test-key")
 
-    # Import after setting the environment variable so the module loads correctly
+    # Import after setting the environment variable so the endpoint uses the test key
     from backend.app.main import app  # pylint: disable=import-error
     import backend.services.api_football as api_football
 
@@ -30,9 +29,10 @@ def test_external_leagues(monkeypatch):
 
 
 def test_missing_api_key(monkeypatch):
-    """Module import should fail if the API key is absent."""
+    """fetch_leagues should raise if the API key is absent."""
     monkeypatch.delenv("API_FOOTBALL_KEY", raising=False)
-    sys.modules.pop("backend.services.api_football", None)
+    from backend.services import api_football
+
     with pytest.raises(RuntimeError):
-        import backend.services.api_football  # noqa: F401, PTC-W003
+        api_football.fetch_leagues()
 


### PR DESCRIPTION
## Summary
- avoid module import failure by removing global API key assertion
- validate `API_FOOTBALL_KEY` inside `fetch_leagues`
- test that missing key now raises at call time

## Testing
- `pytest backend/tests/test_api_football.py`


------
https://chatgpt.com/codex/tasks/task_e_68b722821918832c87bc57c4436d7cd3